### PR TITLE
1.1.3.4h

### DIFF
--- a/system/core/models/phs_plugins.php
+++ b/system/core/models/phs_plugins.php
@@ -349,7 +349,7 @@ class PHS_Model_Plugins extends PHS_Model
 
             // Merge database settings with default script settings
             if( !empty( $default_settings ) )
-                self::$plugin_settings[$instance_id] = self::validate_array_recursive( self::$plugin_settings[$instance_id], $default_settings );
+                self::$plugin_settings[$instance_id] = self::validate_array( self::$plugin_settings[$instance_id], $default_settings );
         }
 
         // Low level hook for plugin settings (allow only keys that are not present in default plugin settings)
@@ -359,7 +359,7 @@ class PHS_Model_Plugins extends PHS_Model
 
         if( ($extra_settings_arr = PHS::trigger_hooks( PHS_Hooks::H_PLUGIN_SETTINGS, $hook_args ))
         and is_array( $extra_settings_arr ) and !empty( $extra_settings_arr['settings_arr'] ) )
-            self::$plugin_settings[$instance_id] = self::validate_array_recursive( $extra_settings_arr['settings_arr'], self::$plugin_settings[$instance_id] );
+            self::$plugin_settings[$instance_id] = self::validate_array( $extra_settings_arr['settings_arr'], self::$plugin_settings[$instance_id] );
 
         return self::$plugin_settings[$instance_id];
     }

--- a/themes/phs_ractivejs/js/ractive_base.js.php
+++ b/themes/phs_ractivejs/js/ractive_base.js.php
@@ -115,7 +115,7 @@ var PHS_RActive = PHS_RActive || Ractive.extend({
         datepicker_month: function( node, args ) {
             var self = this;
             $(node).datepicker({
-                dateFormat: 'yy-mm-01',
+                dateFormat: 'yy-mm',
                 changeMonth: true,
                 changeYear: true,
                 showButtonPanel: true,
@@ -233,6 +233,7 @@ var PHS_RActive = PHS_RActive || Ractive.extend({
     valid_default_response_from_read_data: function( response )
     {
         return (typeof response !== "undefined"
+            && response !== null
             && typeof response.response !== "undefined"
             && response.response !== null
             && typeof response.error !== "undefined"
@@ -243,14 +244,16 @@ var PHS_RActive = PHS_RActive || Ractive.extend({
     get_error_message_for_default_read_data: function( response )
     {
         if( typeof response === "undefined"
+         || response === null
          || typeof response.error === "undefined"
+         || response.response === null
          || typeof response.error.message === "undefined"
          || response.error.message.length === 0 )
             return false;
 
         var error_msg = response.error.message;
         if( typeof response.error.code !== "undefined"
-         && response.error.code != 0 )
+         && parseInt( response.error.code ) !== 0 )
             error_msg = "[" + response.error.code + "] " + error_msg;
 
         return error_msg;


### PR DESCRIPTION
- Changed plugin settings validation to not use validate_array_recursive, but validate_array. Settings might contain arrays which also get validated altering "current" value
- Fixed date picker for months in Ractive theme and response validation from an AJAX call